### PR TITLE
fix(parser): correctly remove prefix + trigger before tokenization

### DIFF
--- a/YouTubeMusicStreamer/Services/Commands/ArgumentParser/ArgumentParser.cs
+++ b/YouTubeMusicStreamer/Services/Commands/ArgumentParser/ArgumentParser.cs
@@ -31,14 +31,14 @@ public partial class ArgumentParser : IArgumentParser
                 .Select(f => f.Text)
         ).Trim();
 
+        if (raw.StartsWith($"{prefix}{trigger}", StringComparison.OrdinalIgnoreCase))
+        {
+            raw = raw[$"{prefix}{trigger}".Length..].TrimStart();
+        }
+
         var tokens = TokenRegex().Matches(raw)
             .Select(m => m.Value.Trim('"'))
             .ToList();
-
-        if (tokens.FirstOrDefault()?.Equals(prefix, StringComparison.OrdinalIgnoreCase) == true)
-            tokens.RemoveAt(0);
-        if (tokens.FirstOrDefault()?.Equals(trigger, StringComparison.OrdinalIgnoreCase) == true)
-            tokens.RemoveAt(0);
 
         return tokens;
     }


### PR DESCRIPTION
Previously, ArgumentParser left the command prefix and trigger in the token list, causing inconsistent argument parsing and potential misalignment with multi-word prefixes (e.g. "music request"). The new logic trims the combined prefix+trigger safely before tokenization.

This is a hotfix release to restore expected command behavior.