### PR TITLE
ci: mirror release build steps in PR workflow and enforce nuget-license errors

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,63 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      OS: win
+      APP_NAME: YouTubeMusicStreamer
+      DOTNET_VERSION: "9.0"
+      ARCH: x64
+      RELEASE_NOTES_FILE: release-notes.md
+      VPK_OUTPUT_DIR: Releases
+      VPK_PACK_AUTHORS: XeroxDev
+      VPK_PACK_TITLE: "YouTube Music Streamer"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare build env
+        shell: pwsh
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+          TWITCH_CLIENT_ID: pr-build
+        run: .\scripts\prepare-build-env.ps1
+
+      - name: Set dynamic VPK env vars
+        shell: pwsh
+        run: |
+          $envBlock = @"
+          VPK_CHANNEL=$($Env:OS)-$($Env:ARCH)
+          VPK_RUNTIME=$($Env:OS)-$($Env:ARCH)
+          VPK_PACK_DIR=./publish/$($Env:OS)-$($Env:ARCH)
+          VPK_FRAMEWORK=webview2,net$($Env:DOTNET_VERSION)-$($Env:ARCH)-desktop
+          VPK_ICON=./$($Env:APP_NAME)/wwwroot/favicon.ico
+          VPK_SPLASH_IMAGE=./$($Env:APP_NAME)/Resources/Splash/splash.png
+          VPK_PACK_VERSION=$($Env:VERSION)
+          VPK_RELEASE_NAME=v$($Env:VERSION)
+          VPK_TAG=v$($Env:VERSION)
+          VPK_TARGET_COMMITISH=$($Env:GITHUB_SHA)
+          VPK_REPO_URL=https://github.com/$($Env:GITHUB_REPOSITORY)
+          VPK_PACK_ID=$($Env:APP_NAME)
+          VPK_MAIN_EXE=$($Env:APP_NAME).exe
+          "@
+          
+          Add-Content -Path $Env:GITHUB_ENV -Value $envBlock -Encoding utf8
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+
+      - name: Publish
+        run: dotnet publish YouTubeMusicStreamer/YouTubeMusicStreamer.csproj -c Release -p:PublishProfile=${{ env.VPK_CHANNEL }}

--- a/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
+++ b/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
@@ -158,8 +158,22 @@
     </UsingTask>
 
     <Target Name="GenerateThirdPartyLicenses" BeforeTargets="BeforeBuild" Condition="'$(Configuration)'=='Release'">
-        <Exec Command="dotnet tool restore"/>
-        <Exec Command="dotnet tool run nuget-license -i $(ProjectDir)$(MSBuildProjectFile) -t -o JsonPretty -d $(ProjectDir)Resources\Raw\ThirdPartyLicenses\ -fo $(ProjectDir)Resources\Raw\third-party-licenses.json -override $(ProjectDir)license-override.json" IgnoreExitCode="true"/>
+        <MakeDir Directories="$(ProjectDir)Resources\Raw\ThirdPartyLicenses" />
+        <Exec Command="dotnet tool restore" />
+        <Exec Command="dotnet tool run nuget-license -i $(ProjectDir)$(MSBuildProjectFile) -t -o JsonPretty -d $(ProjectDir)Resources\Raw\ThirdPartyLicenses\ -fo $(ProjectDir)Resources\Raw\third-party-licenses.json -override $(ProjectDir)license-override.json" IgnoreExitCode="true">
+            <Output TaskParameter="ExitCode" PropertyName="NuGetLicenseExitCode" />
+        </Exec>
+        <Warning Condition="'$(NuGetLicenseExitCode)'=='3'" Text="nuget-license reported validation warnings; see generated files for details." />
+        <Error Condition="'$(NuGetLicenseExitCode)'!='0' AND '$(NuGetLicenseExitCode)'!='3'" Text="nuget-license failed with exit code $(NuGetLicenseExitCode)." />
+
+        <ItemGroup>
+            <MauiAsset Include="$(ProjectDir)Resources\Raw\third-party-licenses.json" LogicalName="third-party-licenses.json">
+                <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            </MauiAsset>
+            <MauiAsset Include="$(ProjectDir)Resources\Raw\ThirdPartyLicenses\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)">
+                <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            </MauiAsset>
+        </ItemGroup>
     </Target>
-    
+
 </Project>

--- a/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
+++ b/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
@@ -167,8 +167,8 @@
         <Error Condition="'$(NuGetLicenseExitCode)'!='0' AND '$(NuGetLicenseExitCode)'!='3'" Text="nuget-license failed with exit code $(NuGetLicenseExitCode)." />
 
         <ItemGroup>
-            <MauiAsset Remove="$(ProjectDir)Resources\Raw\third-party-licenses.json" />
-            <MauiAsset Remove="$(ProjectDir)Resources\Raw\ThirdPartyLicenses\**" />
+            <MauiAsset Remove="Resources\Raw\third-party-licenses.json" />
+            <MauiAsset Remove="Resources\Raw\ThirdPartyLicenses\**" />
             <MauiAsset Include="$(ProjectDir)Resources\Raw\third-party-licenses.json" LogicalName="third-party-licenses.json">
                 <CopyToOutputDirectory>Always</CopyToOutputDirectory>
             </MauiAsset>

--- a/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
+++ b/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
@@ -170,7 +170,7 @@
             <MauiAsset Include="$(ProjectDir)Resources\Raw\third-party-licenses.json" LogicalName="third-party-licenses.json">
                 <CopyToOutputDirectory>Always</CopyToOutputDirectory>
             </MauiAsset>
-            <MauiAsset Include="$(ProjectDir)Resources\Raw\ThirdPartyLicenses\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)">
+            <MauiAsset Include="$(ProjectDir)Resources\Raw\ThirdPartyLicenses\**" LogicalName="ThirdPartyLicenses\%(RecursiveDir)%(Filename)%(Extension)">
                 <CopyToOutputDirectory>Always</CopyToOutputDirectory>
             </MauiAsset>
         </ItemGroup>

--- a/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
+++ b/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
@@ -167,6 +167,8 @@
         <Error Condition="'$(NuGetLicenseExitCode)'!='0' AND '$(NuGetLicenseExitCode)'!='3'" Text="nuget-license failed with exit code $(NuGetLicenseExitCode)." />
 
         <ItemGroup>
+            <MauiAsset Remove="$(ProjectDir)Resources\Raw\third-party-licenses.json" />
+            <MauiAsset Remove="$(ProjectDir)Resources\Raw\ThirdPartyLicenses\**" />
             <MauiAsset Include="$(ProjectDir)Resources\Raw\third-party-licenses.json" LogicalName="third-party-licenses.json">
                 <CopyToOutputDirectory>Always</CopyToOutputDirectory>
             </MauiAsset>


### PR DESCRIPTION
### Motivation
- Make the PR build exercise the same publish semantics as the release `release-build` job so PR checks are more likely to surface release-time publish issues. 
- Ensure third-party license artefacts are generated reliably during Release builds and that `nuget-license` failures are not silently ignored. 
- Include generated license files in publish output so the app can read licenses at runtime.

### Description
- Update ` .github/workflows/pr-build.yml` to add `OS`, `APP_NAME`, `ARCH`, `RELEASE_NOTES_FILE`, `VPK_OUTPUT_DIR`, `VPK_PACK_AUTHORS`, and `VPK_PACK_TITLE` environment variables and to add the `Prepare build env`, `Set dynamic VPK env vars`, `.NET setup`, and NuGet cache steps so the PR job mirrors the release build up through publish while remaining single-arch. 
- Change the PR publish step to run `dotnet publish` with `-p:PublishProfile=${{ env.VPK_CHANNEL }}` so the same publish profile computation is used as in release. 
- In `YouTubeMusicStreamer.csproj` add a `<MakeDir>` to ensure `Resources\Raw\ThirdPartyLicenses` exists before generation and run `dotnet tool restore` then `dotnet tool run nuget-license` while capturing its exit code into `NuGetLicenseExitCode`. 
- Emit a `Warning` when `NuGetLicenseExitCode == 3` and an `Error` for any exit code other than `0` or `3`, and add `MauiAsset` items for `Resources\Raw\third-party-licenses.json` and `Resources\Raw\ThirdPartyLicenses\**` with `CopyToOutputDirectory=Always` so generated license files are packaged.

### Testing
- No automated tests were run because these are workflow and build-target changes that require GitHub Actions (Windows) to validate; CI will run on PRs against `main` and verify the updated steps and publish behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a7329a00832481d527bd5aa57a0e)