### PR TITLE
fix: generate license assets outside maui raw

### DIFF
--- a/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
+++ b/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
@@ -168,6 +168,8 @@
         <Error Condition="'$(NuGetLicenseExitCode)'!='0' AND '$(NuGetLicenseExitCode)'!='3'" Text="nuget-license failed with exit code $(NuGetLicenseExitCode)." />
 
         <ItemGroup>
+            <MauiAsset Remove="$(BaseIntermediateOutputPath)third-party-licenses.json" />
+            <MauiAsset Remove="$(BaseIntermediateOutputPath)ThirdPartyLicenses\**" />
             <MauiAsset Include="$(BaseIntermediateOutputPath)third-party-licenses.json" LogicalName="third-party-licenses.json">
                 <CopyToOutputDirectory>Always</CopyToOutputDirectory>
             </MauiAsset>

--- a/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
+++ b/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
@@ -158,7 +158,7 @@
         </Task>
     </UsingTask>
 
-    <Target Name="GenerateThirdPartyLicenses" BeforeTargets="BeforeBuild" Condition="'$(Configuration)'=='Release'">
+    <Target Name="GenerateThirdPartyLicenses" BeforeTargets="PrepareForPublish" Condition="'$(Configuration)'=='Release'">
         <MakeDir Directories="$(BaseIntermediateOutputPath)ThirdPartyLicenses" />
         <Exec Command="dotnet tool restore" />
         <Exec Command="dotnet tool run nuget-license -i $(ProjectDir)$(MSBuildProjectFile) -t -o JsonPretty -d $(BaseIntermediateOutputPath)ThirdPartyLicenses\ -fo $(BaseIntermediateOutputPath)third-party-licenses.json -override $(ProjectDir)license-override.json" IgnoreExitCode="true">

--- a/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
+++ b/YouTubeMusicStreamer/YouTubeMusicStreamer.csproj
@@ -67,7 +67,8 @@
         <MauiFont Include="Resources\Fonts\*"/>
 
         <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)">
+        <MauiAsset Include="Resources\Raw\**"
+                   LogicalName="%(RecursiveDir)%(Filename)%(Extension)">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </MauiAsset>
 
@@ -158,21 +159,19 @@
     </UsingTask>
 
     <Target Name="GenerateThirdPartyLicenses" BeforeTargets="BeforeBuild" Condition="'$(Configuration)'=='Release'">
-        <MakeDir Directories="$(ProjectDir)Resources\Raw\ThirdPartyLicenses" />
+        <MakeDir Directories="$(BaseIntermediateOutputPath)ThirdPartyLicenses" />
         <Exec Command="dotnet tool restore" />
-        <Exec Command="dotnet tool run nuget-license -i $(ProjectDir)$(MSBuildProjectFile) -t -o JsonPretty -d $(ProjectDir)Resources\Raw\ThirdPartyLicenses\ -fo $(ProjectDir)Resources\Raw\third-party-licenses.json -override $(ProjectDir)license-override.json" IgnoreExitCode="true">
+        <Exec Command="dotnet tool run nuget-license -i $(ProjectDir)$(MSBuildProjectFile) -t -o JsonPretty -d $(BaseIntermediateOutputPath)ThirdPartyLicenses\ -fo $(BaseIntermediateOutputPath)third-party-licenses.json -override $(ProjectDir)license-override.json" IgnoreExitCode="true">
             <Output TaskParameter="ExitCode" PropertyName="NuGetLicenseExitCode" />
         </Exec>
         <Warning Condition="'$(NuGetLicenseExitCode)'=='3'" Text="nuget-license reported validation warnings; see generated files for details." />
         <Error Condition="'$(NuGetLicenseExitCode)'!='0' AND '$(NuGetLicenseExitCode)'!='3'" Text="nuget-license failed with exit code $(NuGetLicenseExitCode)." />
 
         <ItemGroup>
-            <MauiAsset Remove="Resources\Raw\third-party-licenses.json" />
-            <MauiAsset Remove="Resources\Raw\ThirdPartyLicenses\**" />
-            <MauiAsset Include="$(ProjectDir)Resources\Raw\third-party-licenses.json" LogicalName="third-party-licenses.json">
+            <MauiAsset Include="$(BaseIntermediateOutputPath)third-party-licenses.json" LogicalName="third-party-licenses.json">
                 <CopyToOutputDirectory>Always</CopyToOutputDirectory>
             </MauiAsset>
-            <MauiAsset Include="$(ProjectDir)Resources\Raw\ThirdPartyLicenses\**" LogicalName="ThirdPartyLicenses\%(RecursiveDir)%(Filename)%(Extension)">
+            <MauiAsset Include="$(BaseIntermediateOutputPath)ThirdPartyLicenses\**" LogicalName="ThirdPartyLicenses\%(RecursiveDir)%(Filename)%(Extension)">
                 <CopyToOutputDirectory>Always</CopyToOutputDirectory>
             </MauiAsset>
         </ItemGroup>


### PR DESCRIPTION
### Motivation
- Prevent the NETSDK1152 publish conflict that happened when nuget-license generated license files overlapped with the catch-all `MauiAsset Include="Resources\Raw\**"` so they were double-published.
- Avoid using path excludes in `Resources\Raw` as a workaround and instead produce the generated files in an intermediate build directory while preserving their final logical locations.

### Description
- Restored the simple catch-all `MauiAsset Include="Resources\Raw\**"` (no `Exclude`) and moved license generation out of the source tree to avoid duplication at publish time.
- Modified the `GenerateThirdPartyLicenses` target to create `$(BaseIntermediateOutputPath)ThirdPartyLicenses` and run `nuget-license` with output files placed under `$(BaseIntermediateOutputPath)`.
- Added `MauiAsset` includes that point at `$(BaseIntermediateOutputPath)third-party-licenses.json` and `$(BaseIntermediateOutputPath)ThirdPartyLicenses\**` with `LogicalName` mappings so the published layout remains `third-party-licenses.json` and `ThirdPartyLicenses\...`.
- Kept `CopyToOutputDirectory` set to `Always` for the included assets so runtime access and publish output are unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a87b817048324a75f466f2b89397f)